### PR TITLE
Added embassy_async example

### DIFF
--- a/quadrature-encoder/Cargo.toml
+++ b/quadrature-encoder/Cargo.toml
@@ -28,11 +28,22 @@ futures = { version = "0.3.31", default-features = false, optional = true }
 embassy-futures = { version = "0.1.1", optional = true }
 
 [dev-dependencies]
-embedded-hal-mock = { version = "0.11.0", features = [
+embassy-executor = { version = "0.7.0", features = ["task-arena-size-32768", "arch-std", "executor-thread", "log"] }
+embassy-time = { version = "0.4.0", features = ["log","std"] }
+log = "0.4.25"
+env_logger = "0.11.6"
+static_cell = "2.1.0"
+getch-rs = "0.2.0"
+embassy-sync = { version = "0.6.2", features = ["std"] }
+
+[dev-dependencies.embedded-hal-mock]
+git = "https://github.com/leighleighleigh/embedded-hal-mock"
+branch = "async-wait-forever"
+features = [
     "eh0",
     "eh1",
-    "embedded-hal-async",
-] }
+    "embedded-hal-async"
+]
 
 [features]
 default = ["async"]
@@ -61,3 +72,12 @@ required-features = ["async"]
 [[example]]
 name = "linear_async"
 required-features = ["async"]
+
+[[example]]
+name = "embassy_async"
+required-features = ["async"]
+
+[[example]]
+name = "embassy_interactive"
+required-features = ["async"]
+

--- a/quadrature-encoder/examples/embassy_async.rs
+++ b/quadrature-encoder/examples/embassy_async.rs
@@ -1,0 +1,130 @@
+use embassy_executor::Executor;
+use embassy_time::Timer;
+use embedded_hal_mock::eh1::digital::Edge;
+use embedded_hal_mock::eh1::digital::{
+    Mock as PinMock, State as PinState, Transaction as PinTransaction,
+};
+use log::*;
+use quadrature_encoder::{Blocking, IncrementalEncoder, QuadStep, Rotary, RotaryMovement};
+use static_cell::StaticCell;
+
+// helper macros to generate a clockwise/counter-clockwise mock PinTransaction sequences
+macro_rules! cw {
+    ($clk:ident, $dat:ident) => {
+        $clk.push(PinTransaction::wait_for_edge(Edge::Falling));
+        $clk.push(PinTransaction::wait_for_edge_forever(Edge::Rising));
+        $dat.push(PinTransaction::wait_for_edge(Edge::Falling));
+        $clk.push(PinTransaction::wait_for_edge(Edge::Rising));
+        $clk.push(PinTransaction::wait_for_edge_forever(Edge::Falling));
+        $dat.push(PinTransaction::wait_for_edge(Edge::Rising));
+    };
+}
+macro_rules! ccw {
+    ($clk:ident, $dat:ident) => {
+        $clk.push(PinTransaction::wait_for_edge_forever(Edge::Falling));
+        $dat.push(PinTransaction::wait_for_edge(Edge::Falling));
+        $clk.push(PinTransaction::wait_for_edge(Edge::Falling));
+        $clk.push(PinTransaction::wait_for_edge_forever(Edge::Rising));
+        $dat.push(PinTransaction::wait_for_edge(Edge::Rising));
+        $clk.push(PinTransaction::wait_for_edge(Edge::Rising));
+    };
+}
+
+// Number of clockwise rotations to mock
+const CW: usize = 6;
+// Number of counter-clockwise rotations to mock
+const CCW: usize = 9;
+
+// type alias for the encoder - allows easy switching between different step modes
+type Encoder<Clk, Dt, Steps = QuadStep, T = i32, PM = Blocking> =
+    IncrementalEncoder<Rotary, Clk, Dt, Steps, T, PM>;
+
+#[embassy_executor::task]
+async fn encoder_task() {
+    let mut clk_states: Vec<PinTransaction> = Vec::new();
+    let mut dat_states: Vec<PinTransaction> = Vec::new();
+
+    // Initial state of the pins is checked in RotaryEncoder::new()
+    clk_states.push(PinTransaction::get(PinState::High));
+    dat_states.push(PinTransaction::get(PinState::High));
+
+    for _ in 0..CW {
+        cw!(clk_states, dat_states);
+    }
+
+    for _ in 0..CCW {
+        ccw!(clk_states, dat_states);
+    }
+
+    let pin_clk = PinMock::new(&clk_states);
+    let pin_dt = PinMock::new(&dat_states);
+
+    let mut encoder = Encoder::<_, _>::new(pin_clk, pin_dt).into_async();
+    // fetch the number of position steps per rotation - this is dependent on the encoder resolution mode
+    let steps: usize = encoder.pulses_per_cycle();
+    let mut expected_pulse_count = steps * (CW + CCW); // count the absolute number of pulses we expect to receive
+
+    loop {
+        match encoder.poll().await {
+            Ok(Some(movement)) => {
+                let direction = match movement {
+                    RotaryMovement::Clockwise => "⟳ CW",
+                    RotaryMovement::CounterClockwise => "⟲ CCW",
+                };
+                info!(
+                    "Encoder state: {:02b}, position: {} {}",
+                    encoder.raw_state(),
+                    encoder.position(),
+                    direction,
+                );
+                expected_pulse_count -= 1;
+            }
+            Ok(_) => {
+                info!(
+                    "Encoder state: {:02b}, position: {}",
+                    encoder.raw_state(),
+                    encoder.position(),
+                )
+            }
+            Err(error) => error!("Encoder error: {:?}.", error),
+        }
+
+        Timer::after_millis(50).await;
+
+        // break loop after all pulses received,
+        // if the mock was setup properly, then all of the
+        // pin transactions should have been consumed.
+        if expected_pulse_count == 0 {
+            break;
+        }
+    }
+
+    let encoder_position = encoder.position();
+    let expected_position = ((CW as i32) - (CCW as i32)) * (steps as i32);
+    std::assert!(
+        encoder_position == expected_position,
+        "Encoder position {encoder_position} didnt match expectation {expected_position}"
+    );
+
+    // release the pins from the encoder, then finish the embedded_hal_mock test
+    let (mut pin_clk, mut pin_dt) = encoder.release();
+    pin_clk.done();
+    pin_dt.done();
+
+    // quit!
+    std::process::exit(0);
+}
+
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+
+fn main() {
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Debug)
+        .format_timestamp_nanos()
+        .init();
+
+    let executor = EXECUTOR.init(Executor::new());
+    executor.run(|spawner| {
+        spawner.spawn(encoder_task()).unwrap();
+    });
+}

--- a/quadrature-encoder/examples/embassy_interactive.rs
+++ b/quadrature-encoder/examples/embassy_interactive.rs
@@ -1,0 +1,200 @@
+use embassy_executor::Executor;
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::pubsub::{PubSubChannel, Subscriber};
+use embedded_hal_async::digital::Wait;
+use embedded_hal_compat::eh1_0::digital::{ErrorType, InputPin};
+use getch_rs::{Getch, Key};
+use log::*;
+use quadrature_encoder::{Blocking, FullStep, IncrementalEncoder, Rotary, RotaryMovement};
+use static_cell::StaticCell;
+use std::convert::Infallible;
+
+// type alias for the encoder - allows easy switching between different step modes
+type Encoder<Clk, Dt, Steps = FullStep, T = i32, PM = Blocking> =
+    IncrementalEncoder<Rotary, Clk, Dt, Steps, T, PM>;
+
+type GetchPubSub = PubSubChannel<CriticalSectionRawMutex, Key, 64, 2, 1>;
+type GetchSub<'a> = Subscriber<'a, CriticalSectionRawMutex, Key, 64, 2, 1>;
+static GETCH_CHARS: GetchPubSub = PubSubChannel::new();
+
+// Custom Pin type which we will impliment both InputPin and Wait on,
+// using GetCh readings from stdinput, to toggle the state of the pins.
+struct PinGetch<'a> {
+    key: Key,
+    state: bool,
+    // the subscriber to the getch channel
+    getch_sub: GetchSub<'a>,
+}
+
+impl<'a> PinGetch<'a> {
+    fn new(key: Key, initial_state: bool, getch_stream: &'a GetchPubSub) -> Self {
+        Self {
+            key,
+            state: initial_state,
+            getch_sub: getch_stream
+                .subscriber()
+                .expect("got GETCH_CHARS subscriber"),
+        }
+    }
+
+    fn check_for_key(&mut self) -> Result<(), Infallible> {
+        loop {
+            let k = self.getch_sub.try_next_message_pure();
+
+            if let Some(k) = k {
+                if self.key == k {
+                    self.state = !self.state;
+                }
+            } else {
+                // no more keys to check!
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    async fn wait_for_key(&mut self) -> Result<(), Infallible> {
+        loop {
+            let k = self.getch_sub.next_message_pure().await;
+            // toggle when the key is pressed
+            if k == self.key {
+                self.state = !self.state;
+                break;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<'a> ErrorType for PinGetch<'a> {
+    type Error = Infallible;
+}
+
+impl<'a> InputPin for PinGetch<'a> {
+    fn is_high(&mut self) -> Result<bool, Self::Error> {
+        self.check_for_key()?;
+        Ok(self.state)
+    }
+
+    fn is_low(&mut self) -> Result<bool, Self::Error> {
+        self.check_for_key()?;
+        Ok(!self.state)
+    }
+}
+
+impl<'a> Wait for PinGetch<'a> {
+    async fn wait_for_high(&mut self) -> Result<(), Self::Error> {
+        // if we are already high, we don't need to wait
+        if self.state {
+            return Ok(());
+        }
+        // otherwise, wait for the key to be pressed
+        self.wait_for_key().await
+    }
+
+    async fn wait_for_low(&mut self) -> Result<(), Self::Error> {
+        // if we are already low, we don't need to wait
+        if !self.state {
+            return Ok(());
+        }
+        // otherwise, wait for the key to be pressed
+        self.wait_for_key().await
+    }
+
+    async fn wait_for_rising_edge(&mut self) -> Result<(), Self::Error> {
+        // waits for an actual rising edge, even if we are already high
+        self.wait_for_low().await?;
+        self.wait_for_high().await
+    }
+
+    async fn wait_for_falling_edge(&mut self) -> Result<(), Self::Error> {
+        // waits for an actual falling edge, even if we are already low
+        self.wait_for_high().await?;
+        self.wait_for_low().await
+    }
+
+    async fn wait_for_any_edge(&mut self) -> Result<(), Self::Error> {
+        // waits for any change
+        self.wait_for_key().await
+    }
+}
+
+#[embassy_executor::task]
+async fn getch_task() {
+    let pub0 = GETCH_CHARS.publisher().expect("got GETCH_CHARS publisher");
+    let getch = Getch::new();
+
+    info!("Press 'j' / 'k' to toggle CLOCK / DATA.");
+    info!("Press 'q' or <Ctrl-C> to quit.");
+
+    loop {
+        // yield before and after every blocking call,
+        // to allow the encoder task to run
+        embassy_futures::yield_now().await;
+
+        match getch.getch() {
+            Ok(Key::Char('q')) => break,
+            Ok(Key::Ctrl(_)) => break, // any Ctrl- combination will quit (such as Ctrl-C,Ctrl-Z)
+            Ok(key) => pub0.publish(key).await,
+            Err(e) => error!("Error getting key: {:?}", e),
+        }
+
+        embassy_futures::yield_now().await;
+    }
+
+    // quit
+    info!("Quitting.");
+
+    // manually drop the getch to restore the terminal
+    drop(getch);
+
+    std::process::exit(0);
+}
+
+#[embassy_executor::task]
+async fn encoder_task() {
+    let pin_clk = PinGetch::new(Key::Char('j'), true, &GETCH_CHARS);
+    let pin_dt = PinGetch::new(Key::Char('k'), true, &GETCH_CHARS);
+
+    let mut encoder = Encoder::<_, _>::new(pin_clk, pin_dt).into_async();
+
+    loop {
+        match encoder.poll().await {
+            Ok(Some(movement)) => {
+                let direction = match movement {
+                    RotaryMovement::Clockwise => "⟳ CW",
+                    RotaryMovement::CounterClockwise => "⟲ CCW",
+                };
+                info!(
+                    "Encoder state: {:02b}, position: {} {}",
+                    encoder.raw_state(),
+                    encoder.position(),
+                    direction,
+                );
+            }
+            Ok(_) => {
+                info!(
+                    "Encoder state: {:02b}, position: {}",
+                    encoder.raw_state(),
+                    encoder.position(),
+                )
+            }
+            Err(error) => error!("Encoder error: {:?}.", error),
+        }
+    }
+}
+
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+
+fn main() {
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Debug)
+        .format_timestamp_nanos()
+        .init();
+
+    let executor = EXECUTOR.init(Executor::new());
+    executor.run(|spawner| {
+        spawner.spawn(encoder_task()).unwrap();
+        spawner.spawn(getch_task()).unwrap();
+    });
+}

--- a/quadrature-encoder/examples/linear_async.rs
+++ b/quadrature-encoder/examples/linear_async.rs
@@ -1,5 +1,5 @@
 use embassy_futures::block_on;
-use embedded_hal_mock::eh1::digital::Edge;
+use embedded_hal_mock::eh1::digital::State;
 use embedded_hal_mock::eh1::digital::{
     Mock as PinMock, State as PinState, Transaction as PinTransaction,
 };
@@ -9,7 +9,7 @@ use quadrature_encoder::{LinearEncoder, LinearMovement};
 fn main() {
     let pin_clk = PinMock::new(&[
         PinTransaction::get(PinState::High),
-        PinTransaction::wait_for_edge(Edge::Falling),
+        PinTransaction::wait_for_state(State::Low),
     ]);
     let pin_dt = PinMock::new(&[PinTransaction::get(PinState::High)]);
 

--- a/quadrature-encoder/examples/rotary_async.rs
+++ b/quadrature-encoder/examples/rotary_async.rs
@@ -1,5 +1,5 @@
 use embassy_futures::block_on;
-use embedded_hal_mock::eh1::digital::Edge;
+use embedded_hal_mock::eh1::digital::State;
 use embedded_hal_mock::eh1::digital::{
     Mock as PinMock, State as PinState, Transaction as PinTransaction,
 };
@@ -8,7 +8,7 @@ use quadrature_encoder::{RotaryEncoder, RotaryMovement};
 fn main() {
     let pin_clk = PinMock::new(&[
         PinTransaction::get(PinState::High),
-        PinTransaction::wait_for_edge(Edge::Falling),
+        PinTransaction::wait_for_state(State::Low),
     ]);
     let pin_dt = PinMock::new(&[PinTransaction::get(PinState::High)]);
 

--- a/quadrature-encoder/src/encoder/incremental.rs
+++ b/quadrature-encoder/src/encoder/incremental.rs
@@ -213,15 +213,18 @@ where
     /// Waits asynchronously for any of the pins to change state, before returning.
     pub async fn poll(&mut self) -> Result<Option<Mode::Movement>, Error> {
         let clk_fut = match self.pin_clk_state {
-            true => self.pin_clk.wait_for_falling_edge().left_future(),
-            false => self.pin_clk.wait_for_rising_edge().right_future(),
+            true => self.pin_clk.wait_for_low().left_future(),
+            false => self.pin_clk.wait_for_high().right_future(),
         };
 
         let dt_fut = match self.pin_dt_state {
-            true => self.pin_dt.wait_for_falling_edge().left_future(),
-            false => self.pin_dt.wait_for_rising_edge().right_future(),
+            true => self.pin_dt.wait_for_low().left_future(),
+            false => self.pin_dt.wait_for_high().right_future(),
         };
 
+        // toggle the internal state, rather than reading the pin state directly,
+        // as the pin state has likely changed since the wait_for_low() future was resolved
+        // by the hardware interrupt behind-the-scenes.
         match select(clk_fut, dt_fut).await {
             Either::First(_) => {
                 self.pin_clk_state = !self.pin_clk_state;
@@ -230,6 +233,7 @@ where
                 self.pin_dt_state = !self.pin_dt_state;
             }
         };
+
         self.update()
     }
 

--- a/quadrature-encoder/src/encoder/incremental.rs
+++ b/quadrature-encoder/src/encoder/incremental.rs
@@ -133,6 +133,16 @@ where
             false => self.decoder.set_counter(position),
         }
     }
+
+    /// Return the pin state as gray-code binary value
+    pub fn raw_state(&self) -> u8 {
+        (self.pin_clk_state as u8) | (self.pin_dt_state as u8) << 1
+    }
+
+    /// The number of pulses per full quadrature cycle, depending on the step mode.
+    pub const fn pulses_per_cycle(&self) -> usize {
+        Steps::PULSES_PER_CYCLE
+    }
 }
 
 impl<Mode, Clk, Dt, Steps, T> IncrementalEncoder<Mode, Clk, Dt, Steps, T, Blocking>

--- a/quadrature-encoder/src/encoder/indexed.rs
+++ b/quadrature-encoder/src/encoder/indexed.rs
@@ -137,6 +137,18 @@ where
             false => self.decoder.set_counter(position),
         }
     }
+
+    /// Return the pin state as gray-code binary value
+    pub fn raw_state(&self) -> u8 {
+        (self.pin_clk_state as u8)
+            | (self.pin_dt_state as u8) << 1
+            | (self.pin_idx_state as u8) << 2
+    }
+
+    /// The number of pulses per full quadrature cycle, depending on the step mode.
+    pub const fn pulses_per_cycle(&self) -> usize {
+        Steps::PULSES_PER_CYCLE
+    }
 }
 
 impl<Mode, Clk, Dt, Idx, Steps, T> IndexedIncrementalEncoder<Mode, Clk, Dt, Idx, Steps, T, Blocking>


### PR DESCRIPTION
Adds a couple examples using `embassy` as the async runtime.

Output from the `embassy_interactive` example below:
```shell
$ cargo run --release --example embassy_interactive
[2025-01-25T02:04:05.369928085Z INFO  embassy_interactive] Press 'j' / 'k' to toggle CLOCK / DATA.
[2025-01-25T02:04:05.369936235Z INFO  embassy_interactive] Press 'q' or <Ctrl-C> to quit.
[2025-01-25T02:04:07.416407696Z INFO  embassy_interactive] Encoder state: 10, position: 0
[2025-01-25T02:04:07.880959699Z INFO  embassy_interactive] Encoder state: 11, position: 0
[2025-01-25T02:04:08.563606782Z INFO  embassy_interactive] Encoder state: 10, position: 0
[2025-01-25T02:04:08.649179315Z INFO  embassy_interactive] Encoder state: 00, position: 0
[2025-01-25T02:04:08.979300606Z INFO  embassy_interactive] Encoder state: 01, position: 0
[2025-01-25T02:04:09.007046126Z INFO  embassy_interactive] Encoder state: 11, position: 1 ⟳ CW
[2025-01-25T02:04:09.295522785Z INFO  embassy_interactive] Encoder state: 10, position: 1
[2025-01-25T02:04:09.342246093Z INFO  embassy_interactive] Encoder state: 00, position: 1
[2025-01-25T02:04:09.576509498Z INFO  embassy_interactive] Encoder state: 01, position: 1
[2025-01-25T02:04:09.604006212Z INFO  embassy_interactive] Encoder state: 11, position: 2 ⟳ CW
[2025-01-25T02:04:09.819317522Z INFO  embassy_interactive] Encoder state: 10, position: 2
[2025-01-25T02:04:09.896343074Z INFO  embassy_interactive] Encoder state: 00, position: 2
[2025-01-25T02:04:10.091519832Z INFO  embassy_interactive] Encoder state: 01, position: 2
[2025-01-25T02:04:10.151558628Z INFO  embassy_interactive] Encoder state: 11, position: 3 ⟳ CW
[2025-01-25T02:04:10.378198176Z INFO  embassy_interactive] Encoder state: 10, position: 3
[2025-01-25T02:04:10.437906900Z INFO  embassy_interactive] Encoder state: 00, position: 3
[2025-01-25T02:04:11.019701699Z INFO  embassy_interactive] Encoder state: 10, position: 3
[2025-01-25T02:04:11.067929591Z INFO  embassy_interactive] Encoder state: 11, position: 3
[2025-01-25T02:04:11.285487417Z INFO  embassy_interactive] Encoder state: 01, position: 3
[2025-01-25T02:04:11.329270411Z INFO  embassy_interactive] Encoder state: 00, position: 3
[2025-01-25T02:04:11.509520585Z INFO  embassy_interactive] Encoder state: 10, position: 3
[2025-01-25T02:04:11.550511330Z INFO  embassy_interactive] Encoder state: 11, position: 2 ⟲ CCW
[2025-01-25T02:04:11.732226861Z INFO  embassy_interactive] Encoder state: 01, position: 2
[2025-01-25T02:04:11.770874756Z INFO  embassy_interactive] Encoder state: 00, position: 2
[2025-01-25T02:04:11.950554969Z INFO  embassy_interactive] Encoder state: 10, position: 2
[2025-01-25T02:04:11.986100827Z INFO  embassy_interactive] Encoder state: 11, position: 1 ⟲ CCW
[2025-01-25T02:04:12.169547752Z INFO  embassy_interactive] Encoder state: 01, position: 1
[2025-01-25T02:04:12.190858973Z INFO  embassy_interactive] Encoder state: 00, position: 1
[2025-01-25T02:04:12.391574487Z INFO  embassy_interactive] Encoder state: 10, position: 1
[2025-01-25T02:04:12.456595624Z INFO  embassy_interactive] Encoder state: 11, position: 0 ⟲ CCW
[2025-01-25T02:04:15.435530711Z INFO  embassy_interactive] Quitting.
```